### PR TITLE
Fix unknown property 'stackSize' in Item type

### DIFF
--- a/src/store/__tests__/gameStore.test.ts
+++ b/src/store/__tests__/gameStore.test.ts
@@ -50,7 +50,7 @@ describe('gameStore', () => {
         })
         
         const item = getInventoryItem('iron-plate')
-        expect(item.amount).toBe(10)
+        expect(item.currentAmount).toBe(10)
         expect(item.itemId).toBe('iron-plate')
       })
 
@@ -63,7 +63,7 @@ describe('gameStore', () => {
         })
         
         const item = getInventoryItem('iron-plate')
-        expect(item.amount).toBe(15)
+        expect(item.currentAmount).toBe(15)
       })
 
       it('should handle negative amounts', () => {
@@ -75,7 +75,7 @@ describe('gameStore', () => {
         })
         
         const item = getInventoryItem('iron-plate')
-        expect(item.amount).toBe(15)
+        expect(item.currentAmount).toBe(15)
       })
 
       it('should remove item when amount reaches zero', () => {
@@ -102,9 +102,9 @@ describe('gameStore', () => {
           ])
         })
         
-        expect(getInventoryItem('iron-plate').amount).toBe(10)
-        expect(getInventoryItem('copper-plate').amount).toBe(20)
-        expect(getInventoryItem('steel-plate').amount).toBe(5)
+        expect(getInventoryItem('iron-plate').currentAmount).toBe(10)
+        expect(getInventoryItem('copper-plate').currentAmount).toBe(20)
+        expect(getInventoryItem('steel-plate').currentAmount).toBe(5)
       })
     })
 
@@ -119,9 +119,15 @@ describe('gameStore', () => {
         const item = getInventoryItem('iron-plate')
         expect(item).toEqual({
           itemId: 'iron-plate',
-          amount: 10,
+          currentAmount: 10,
           stackSize: 100,
-          capacity: 100
+          baseStacks: 1,
+          additionalStacks: 0,
+          totalStacks: 1,
+          maxCapacity: 100,
+          productionRate: 0,
+          consumptionRate: 0,
+          status: 'normal'
         })
       })
 
@@ -131,9 +137,15 @@ describe('gameStore', () => {
         const item = getInventoryItem('non-existent')
         expect(item).toEqual({
           itemId: 'non-existent',
-          amount: 0,
+          currentAmount: 0,
           stackSize: 100,
-          capacity: 100
+          baseStacks: 1,
+          additionalStacks: 0,
+          totalStacks: 1,
+          maxCapacity: 100,
+          productionRate: 0,
+          consumptionRate: 0,
+          status: 'normal'
         })
       })
     })


### PR DESCRIPTION
Align `gameStore.test.ts` expectations with `InventoryItem` interface to resolve TypeScript error.

The error "Object literal may only specify known properties, and 'stackSize' does not exist in type 'Item'.ts(2353)" occurred because tests were expecting properties like `amount` and `capacity` on an `Item` type, while `getInventoryItem` returns an `InventoryItem` which uses `currentAmount`, `maxCapacity`, and a more comprehensive set of properties. This PR updates the test assertions to match the actual `InventoryItem` structure, including `stackSize`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f5b483b-99a9-47ae-90ec-665bf6e66315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f5b483b-99a9-47ae-90ec-665bf6e66315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>