### PR TITLE
Improve FloatingTaskList layout and quantity display; fix ItemDetailPanel float text and simplify ProductionModule layout

### DIFF
--- a/src/components/common/FloatingTaskList.tsx
+++ b/src/components/common/FloatingTaskList.tsx
@@ -25,25 +25,46 @@ const FloatingTaskList: React.FC = () => {
   const itemSize = isMobile ? 44 : 56;
   const gap = isMobile ? 0.5 : 1;
 
+  const getDisplayQuantity = (task: (typeof activeTasks)[number]): number => {
+    const recipe = dataService.getRecipe(task.recipeId);
+    if (!recipe?.out) {
+      return task.quantity;
+    }
+
+    const outputPerCraft = recipe.out[task.itemId] ?? Object.values(recipe.out)[0];
+    return task.quantity * Number(outputPerCraft || 1);
+  };
+
   return (
     <Box
       sx={{
         position: 'fixed',
-        // 56px 为移动端固定 tabbar 高度，再留 20px 间距
-        bottom: 76,
-        left: 20,
+        // 56px 为移动端固定 tabbar 高度，再留 12px 间距
+        bottom: 68,
+        left: 0,
+        width: '100%',
         zIndex: 1250,
         display: 'flex',
         flexDirection: 'column',
+        alignItems: 'center',
         gap,
-        maxWidth: `${itemSize * 6 + gap * 5}px`,
+        boxSizing: 'border-box',
+        px: isMobile ? 1 : 1.5,
+        py: isMobile ? 0.75 : 1,
+        borderRadius: 1.5,
+        bgcolor: 'rgba(0, 0, 0, 0.45)',
+        backdropFilter: 'blur(6px)',
+        boxShadow: '0 6px 20px rgba(0, 0, 0, 0.35)',
         pointerEvents: 'auto', // 允许点击交互
       }}
     >
       {Array.from({ length: Math.min(Math.ceil(activeTasks.length / 6), 3) }, (_, rowIndex) => {
         const rowTasks = activeTasks.slice(rowIndex * 6, (rowIndex + 1) * 6);
         return (
-          <Box key={rowIndex} sx={{ display: 'flex', gap, justifyContent: 'flex-start' }}>
+          <Box
+            key={rowIndex}
+            sx={{ display: 'flex', gap, justifyContent: 'center', width: '100%' }}
+          >
             {rowTasks.map(task => {
               const item = dataService.getItem(task.itemId);
               if (!item) return null;
@@ -76,7 +97,7 @@ const FloatingTaskList: React.FC = () => {
                   <FactorioIcon
                     itemId={task.itemId}
                     size={itemSize}
-                    quantity={task.quantity > 1 ? task.quantity : undefined}
+                    quantity={getDisplayQuantity(task) > 1 ? getDisplayQuantity(task) : undefined}
                   />
                   {/* 合并标识 */}
                   {task.isMerged && (

--- a/src/components/production/ItemDetailPanel.tsx
+++ b/src/components/production/ItemDetailPanel.tsx
@@ -36,7 +36,8 @@ const ItemDetailPanel: React.FC<ItemDetailPanelProps> = ({ item, onItemSelect })
   const idRef = useRef(0);
 
   const addFloatingText = useCallback(
-    (text: string, event: React.MouseEvent<HTMLButtonElement>) => {
+    (text: string, event?: React.MouseEvent<HTMLButtonElement>) => {
+      if (!event) return;
       const rect = event.currentTarget.getBoundingClientRect();
       const id = ++idRef.current;
       setFloatingTexts(prev => [...prev, { id, text, x: rect.left + rect.width / 2, y: rect.top }]);
@@ -50,7 +51,7 @@ const ItemDetailPanel: React.FC<ItemDetailPanelProps> = ({ item, onItemSelect })
       itemId: string,
       quantity: number,
       recipe: Recipe,
-      event: React.MouseEvent<HTMLButtonElement>
+      event?: React.MouseEvent<HTMLButtonElement>
     ) => {
       const result = handleManualCraft(itemId, quantity, recipe);
       if (result !== null) {
@@ -67,6 +68,7 @@ const ItemDetailPanel: React.FC<ItemDetailPanelProps> = ({ item, onItemSelect })
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
+        minHeight: 0,
         bgcolor: 'background.default',
       }}
     >
@@ -86,6 +88,7 @@ const ItemDetailPanel: React.FC<ItemDetailPanelProps> = ({ item, onItemSelect })
       <Box
         sx={{
           flex: 1,
+          minHeight: 0,
           overflow: 'auto',
           p: 1,
           overscrollBehavior: 'none',

--- a/src/components/production/ProductionModule.tsx
+++ b/src/components/production/ProductionModule.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from 'react';
 
 import CategoryTabs from '@/components/common/CategoryTabs';
 import FloatingTaskList from '@/components/common/FloatingTaskList';
-import CraftingQueue from '@/components/production/CraftingQueue';
 import ItemDetailPanel from '@/components/production/ItemDetailPanel';
 import ItemList from '@/components/production/ItemList';
 
@@ -18,11 +17,9 @@ const ProductionModule: React.FC = React.memo(() => {
   const selectedCategory = useGameStore(state => state.production.selectedCategory);
   const selectedItem = useGameStore(state => state.production.selectedItem);
   const isItemJump = useGameStore(state => state.production.isItemJump);
-  const showCraftingQueue = useGameStore(state => state.production.showCraftingQueue);
   const selectProductionCategory = useGameStore(state => state.selectProductionCategory);
   const selectProductionItem = useGameStore(state => state.selectProductionItem);
   const resetItemJump = useGameStore(state => state.resetItemJump);
-  const setCraftingQueueVisible = useGameStore(state => state.setCraftingQueueVisible);
   const autoSelectFirstItemIfNeeded = useGameStore(state => state.autoSelectFirstItemIfNeeded);
   const getFirstItemInCategory = useGameStore(state => state.getFirstItemInCategory);
 
@@ -70,7 +67,7 @@ const ProductionModule: React.FC = React.memo(() => {
       </Box>
 
       {/* 主要内容区域 - 左右分割 */}
-      <Box sx={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+      <Box sx={{ flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 }}>
         {/* 左侧物品列表 */}
         <Box
           sx={{
@@ -78,6 +75,7 @@ const ProductionModule: React.FC = React.memo(() => {
             display: 'flex',
             flexDirection: 'column',
             overflow: 'hidden',
+            minHeight: 0,
             borderRight: 1,
             borderColor: 'divider',
           }}
@@ -90,7 +88,7 @@ const ProductionModule: React.FC = React.memo(() => {
         </Box>
 
         {/* 右侧物品详情 */}
-        <Box sx={{ flex: 1, overflow: 'hidden' }}>
+        <Box sx={{ flex: 1, overflow: 'hidden', minHeight: 0 }}>
           {selectedItem ? (
             <ItemDetailPanel item={selectedItem} onItemSelect={selectProductionItem} />
           ) : (
@@ -106,9 +104,6 @@ const ProductionModule: React.FC = React.memo(() => {
           )}
         </Box>
       </Box>
-
-      {/* 制作队列弹窗 */}
-      <CraftingQueue open={showCraftingQueue} onClose={() => setCraftingQueueVisible(false)} />
 
       {/* 浮动任务列表 - 左下角自动显示 */}
       <FloatingTaskList />


### PR DESCRIPTION
### Motivation
- Make the floating crafting task list visually consistent and centered across breakpoints while showing correct produced item counts when recipes have multiple outputs. 
- Prevent errors and missed floating feedback when the floating text callback is invoked without an event. 
- Simplify the production module layout to avoid overflow/scrolling layout issues and remove the unused crafting queue panel.

### Description
- Enhance `FloatingTaskList` to calculate displayed quantities from recipe outputs via `getDisplayQuantity`, center rows, expand to full width, and add styling (padding, backdrop blur, rounded corners, shadow), and adjust bottom offset. 
- Update `FactorioIcon` quantity prop to use the computed display quantity. 
- Make `addFloatingText` and `onManualCraft` callbacks in `ItemDetailPanel` accept optional event parameters and guard when `event` is absent. 
- Add `minHeight: 0` to several containers (`ItemDetailPanel`, `ProductionModule` and child boxes) to fix flexbox overflow/scroll behavior. 
- Remove the `CraftingQueue` import and its rendering from `ProductionModule`, and remove selectors related to its visibility. 

### Testing
- Ran unit tests with `yarn test` and all tests passed. 
- Ran type check and build with `yarn build` and `tsc` and both completed successfully. 
- Ran linting with `yarn lint` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a329d392d4832fa00619d2b0ffe85f)